### PR TITLE
refine commit date picker

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -7768,7 +7768,7 @@
                                               |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594017909778) (:text |:date) (:id |QazagzTIMe)
                                               |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594017909778) (:text |x) (:id |ecqIW6gVNz)
                                             :id |OAjxLGAnNj
-                                          |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594018095079) (:text |;) (:id |ALeigAvmN)
+                                          |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594984166869) (:text |;) (:id |kQjhopPy3C)
                                         :id |xshnzI2AwpB
                                       |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016362662)
                                         :data $ {}
@@ -8307,7 +8307,7 @@
                                               |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |result) (:id |BYZLj4mX76J)
                                               |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |:commit) (:id |MVS7ChayLWY)
                                               |v $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594017974706) (:text |:date) (:id |O7F_lp8yxCU)
-                                              |t $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594018007866) (:text |:committer) (:id |LNxEP6hgxV)
+                                              |t $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594984090045) (:text |:author) (:id |LNxEP6hgxV)
                                             :id |PsouhgciuW1
                                         :id |EbMKlQ6_cHQ
                                       |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
@@ -9008,12 +9008,6 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426449103) (:text |<<) (:id |DkgjUZVl9r)
                               |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553427521963) (:text "|\"Automated cherry pick of ~{pr-names}") (:id |Y7LJXSnlXS)
-                      |D $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553426039813) (:id |CkxgwSpt8x)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426039813) (:text |<commands) (:id |0ZGbkBNsEN)
-                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553426039813) (:id |-evy8FR_0Q)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426039813) (:text |chan) (:id |qdvINJ92H0)
                   |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553424302382) (:id |sPm6MWBh4V)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553424302382) (:text |d!) (:id |rfRfPMHQeC)
@@ -9145,13 +9139,6 @@
                                           |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426044335) (:text |string/replace) (:id |fkmdm0ge_07)
                                           |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426044335) (:text "|\"'") (:id |2nUbLtsmZ7N)
                                           |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426044335) (:text "|\"\\'") (:id |JpO8L8H0vpP)
-                              |yyj $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553426044335) (:id |PcA_eHu1prC)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426044335) (:text |commands) (:id |lK8QwJKxYza)
-                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553426044335) (:id |drUlXoGKDdZ)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426044335) (:text |<<) (:id |dmlJCwF2Lo3)
-                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594011568935) (:text "|\"git checkout -b ~{new-branch} origin/~{release-branch}\n\n~{commands-pick-commits}\n\ngit push origin ~{new-branch}\n\n~{pr-command}\n") (:id |9QWgO0R0tPd)
                               |yyb $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594011499895)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594011509207) (:text |pr-command) (:id |-2TB5rttgKleaf)
@@ -9232,12 +9219,11 @@
                                         :id |EZJ53mjNA
                                     :id |nubCw9CCl4
                                 :id |-2TB5rttgK
-                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553427114182) (:id |MTyoTLwWq4)
+                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594983896396)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553427114182) (:text |>!) (:id |ZagV0IUcGb)
-                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553427114182) (:text |<commands) (:id |TwJfGJGNW0)
-                              |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553427114182) (:text |commands) (:id |OpLu1jprMW)
-                  |x $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1553426051504) (:text |<commands) (:id |HxJRWeYcG)
+                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594983896396) (:text |<<) (:id |99jqZTsWa-)
+                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594983896396) (:text "|\"git checkout -b ~{new-branch} origin/~{release-branch}\n\n~{commands-pick-commits}\n\ngit push origin ~{new-branch}\n\n~{pr-command}\n") (:id |CBaPsLia7m)
+                            :id |cLqP-j2DJD
         :proc $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1553423216630) (:id |bZJJEXkRHQ) (:data $ {})
       |app.comp.profile $ {}
         :ns $ {} (:type :expr) (:id |ByC9-5Lee0rW) (:by nil) (:at 1500541010211)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rebase-hell",
-  "version": "0.2.5",
+  "version": "0.2.6-a1",
   "description": "Cumulo Workflow",
   "main": "index.js",
   "bin": {

--- a/src/app/util/github.cljs
+++ b/src/app/util/github.cljs
@@ -54,7 +54,7 @@
          next-acc (conj
                    acc
                    {:commit {:message (-> result :commit :message)},
-                    :date (-> result :commit :committer :date),
+                    :date (-> result :commit :author :date),
                     :sha current-sha})
          parent-sha (get-in result [:parents 0 :sha])]
      (comment println (pr-str "COMMIT DATA" parent-sha base-sha result))
@@ -171,8 +171,7 @@
        last))
 
 (defn get-commands-chan! [pr-ids upstream d!]
-  (let [<commands (chan)
-        release-branch (get-release-branch!)
+  (let [release-branch (get-release-branch!)
         pr-names-list (->> pr-ids (map (fn [x] (str "#" x))))
         pr-names (->> pr-names-list (string/join " "))
         pr-names-dashed (string/join "-" pr-ids)
@@ -208,8 +207,6 @@
                                       :head new-branch,
                                       :base release-branch}))]
                           (<<
-                           "curl -d '~{data}' -H \"Content-Type: application/json\" --header \"Authorization: token ~{gitea-token}\" -X POST ~{gitea-host}/repos/~{upstream}/pulls")))
-           commands (<<
-                     "git checkout -b ~{new-branch} origin/~{release-branch}\n\n~{commands-pick-commits}\n\ngit push origin ~{new-branch}\n\n~{pr-command}\n")]
-       (>! <commands commands)))
-    <commands))
+                           "curl -d '~{data}' -H \"Content-Type: application/json\" --header \"Authorization: token ~{gitea-token}\" -X POST ~{gitea-host}/repos/~{upstream}/pulls")))]
+       (<<
+        "git checkout -b ~{new-branch} origin/~{release-branch}\n\n~{commands-pick-commits}\n\ngit push origin ~{new-branch}\n\n~{pr-command}\n")))))


### PR DESCRIPTION
Gitea 返回的数据结构当中的有两个时间, 推测 committer 时间是跟着 rebase 的重写会被重写的, 所以按照 committer date 进行排序, 不一定对, 实际测试数据当中返回都是秒级别的, 不够精确. 所以改成 author date, 应该不会出现难以正确排序了.

```js
  "commit": {
    "url": "https://git....",
    "author": {
      "name": "ChenYong",
      "email": "chenyong@xxx",
      "date": "2020-07-14T20:07:45+08:00"
    },
    "committer": {
      "name": "ChenYong",
      "email": "chenyong@xxx",
      "date": "2020-07-15T16:11:23+08:00"
    },
```