### PR TITLE
fix: put more logs when failure happens in grabbing commits

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -8615,11 +8615,21 @@
                                   |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |nil?) (:id |tIQNdaCMeQ6)
                                   |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |parent-sha) (:id |q2NJtD1wm7Y)
                                 :id |uIsO5FKWr2X
-                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
+                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748365049)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |on-error) (:id |J-i-SoJoYh-)
-                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text "|\"parent sha is nil") (:id |FdySzcrTHz0)
-                                :id |aZVrp5Ubxh7
+                                  |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |on-error) (:id |J-i-SoJoYh-)
+                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text "|\"parent sha is nil") (:id |FdySzcrTHz0)
+                                    :id |aZVrp5Ubxh7
+                                  |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748366756) (:text |do) (:id |-blQcKR7r)
+                                  |L $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748368657)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748369530) (:text |println) (:id |ooI55TSeHW)
+                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748822647) (:text "|\"parent sha is nil, gets nothing") (:id |LgiJkUxru4)
+                                    :id |MBH-moXEk
+                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748379741) (:text |nil) (:id |vrlePQKQ8)
+                                :id |odm_x2-A24
                             :id |p0highK4NOK
                           |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
                             :data $ {}
@@ -8629,11 +8639,31 @@
                                   |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |size) (:id |BuVr9H6DtYx)
                                   |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |10) (:id |prSU9WFBMCk)
                                 :id |EedSaIf4GTw
-                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
+                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748386038)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |on-error) (:id |Dvu6uSyjdMx)
-                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text "|\"loop size too large") (:id |RuzDRbm1SSB)
-                                :id |qbAye8l9u-R
+                                  |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1594016815414) (:text |on-error) (:id |Dvu6uSyjdMx)
+                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748833759) (:text "|\"loop size too large, nothing to return, might be in wrong repo?") (:id |RuzDRbm1SSB)
+                                    :id |qbAye8l9u-R
+                                  |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748386562) (:text |do) (:id |oIAf6jUAf)
+                                  |L $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748387362)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748397977) (:text |println) (:id |gMmCJjMygv)
+                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748410890) (:text "|\"Loop not stopped...") (:id |uFxxQRGCX)
+                                      |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748421358) (:text |parent-sha) (:id |V2zjMLp6e)
+                                    :id |uZ9ThALE7
+                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748393698) (:text |nil) (:id |uPxYeGmuY4)
+                                  |P $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748552464)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748553184) (:text |println) (:id |kUxwsyKlMleaf)
+                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1597748553717)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748553717) (:text |pr-str) (:id |IEdQUc0W8E)
+                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1597748553717) (:text |next-acc) (:id |mDxMFv9lCT)
+                                        :id |ET6ROhygeG
+                                    :id |kUxwsyKlM
+                                :id |PBvdEOuqE
                             :id |uRYU6vcGIrA
                           |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1594016815414)
                             :data $ {}

--- a/dev-apps.edn
+++ b/dev-apps.edn
@@ -1,0 +1,5 @@
+{
+ :users {}
+ :enabled-apps #{}
+ :all-apps []
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rebase-hell",
-  "version": "0.2.7-a5",
+  "version": "0.2.7-a6",
   "description": "Cumulo Workflow",
   "main": "index.js",
   "bin": {

--- a/src/app/util/github.cljs
+++ b/src/app/util/github.cljs
@@ -59,8 +59,14 @@
          parent-sha (get-in result [:parents 0 :sha])]
      (comment println (pr-str "COMMIT DATA" parent-sha base-sha result))
      (cond
-       (nil? parent-sha) (on-error "parent sha is nil")
-       (> size 10) (on-error "loop size too large")
+       (nil? parent-sha)
+         (do (println "parent sha is nil, gets nothing") (on-error "parent sha is nil") nil)
+       (> size 10)
+         (do
+          (println "Loop not stopped..." parent-sha)
+          (println (pr-str next-acc))
+          (on-error "loop size too large, nothing to return, might be in wrong repo?")
+          nil)
        (= base-sha parent-sha) next-acc
        :else (recur next-acc parent-sha (inc size))))))
 


### PR DESCRIPTION
抓取错误的仓库的时候, 无法通过判断 id 停止, 最后报错了, 加一个 nil 的处理和一些 logs.
