### PR TITLE
render smaller footprints list

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -6023,25 +6023,33 @@
                                           |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:style)
-                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486427833)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                  |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:line-height)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |1.2)
-                                                  |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:padding)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185792846) (:text "|\"6px 4px")
-                                                  |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:overflow)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:hidden)
-                                                  |x $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185745904) (:text |:cursor)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185747286) (:text |:pointer)
+                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |{})
+                                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:line-height)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486392810) (:text "|\"1.4em")
+                                                      |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:padding)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486463328) (:text "|\"6px 6px")
+                                                      |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:overflow)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:hidden)
+                                                      |x $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185745904) (:text |:cursor)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185747286) (:text |:pointer)
+                                                      |t $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486442525)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486444840) (:text |:font-size)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486455398) (:text |13)
+                                                  |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486428847) (:text |merge)
+                                                  |L $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486430599) (:text |ui/row-parted)
                                           |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:on-click)
@@ -6061,100 +6069,57 @@
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185779103) (:text |:class-name)
                                               |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185781903) (:text "|\"hoverable")
+                                          |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486261630)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486263759) (:text |:title)
+                                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486373032) (:text |k)
                                       |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |div)
-                                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |{})
-                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195435414)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195436246) (:text |:style)
-                                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195438104) (:text |ui/row-parted)
-                                          |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |<>)
-                                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |v)
-                                              |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195846701) (:text |ui/expand)
-                                          |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195754481)
-                                            :data $ {}
-                                              |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195439566)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195442867) (:text |comp-icon)
-                                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195461803) (:text |:x)
-                                                  |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195464691)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195464403) (:text |{})
-                                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195465392)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195466571) (:text |:font-size)
-                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195469145) (:text |14)
-                                                      |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195469625)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195470594) (:text |:color)
-                                                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195470814)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195471204) (:text |hsl)
-                                                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195799478) (:text |0)
-                                                              |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195636738) (:text |90)
-                                                              |v $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195638076) (:text |70)
-                                                  |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195477969)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195480388) (:text |fn)
-                                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195480793)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195481058) (:text |e)
-                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195482261) (:text |d!)
-                                                      |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195486461)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195487866) (:text |d!)
-                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195602243) (:text |:session/drop-footprint)
-                                                          |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195498535) (:text |k)
-                                              |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195755258) (:text |span)
-                                              |L $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195755721)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195756046) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195756833)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195756833) (:text |:class-name)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195767748) (:text "|\"close-icon")
-                                      |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |<>)
+                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |v)
+                                          |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195846701) (:text |ui/expand)
+                                      |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195754481)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |div)
-                                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                          |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195439566)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |{})
-                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195442867) (:text |comp-icon)
+                                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195461803) (:text |:x)
+                                              |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195464691)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:style)
-                                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195464403) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195465392)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |{})
-                                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195466571) (:text |:font-size)
+                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486421164) (:text |14)
+                                                  |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195469625)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195470594) (:text |:color)
+                                                      |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195470814)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:font-size)
-                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |10)
-                                                      |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |:color)
-                                                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |hsl)
-                                                              |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |0)
-                                                              |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |0)
-                                                              |v $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |70)
-                                          |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195471204) (:text |hsl)
+                                                          |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195799478) (:text |0)
+                                                          |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195636738) (:text |90)
+                                                          |v $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195638076) (:text |70)
+                                              |v $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195477969)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195480388) (:text |fn)
+                                                  |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195480793)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195481058) (:text |e)
+                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195482261) (:text |d!)
+                                                  |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195486461)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195487866) (:text |d!)
+                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195602243) (:text |:session/drop-footprint)
+                                                      |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195498535) (:text |k)
+                                          |D $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195755258) (:text |span)
+                                          |L $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195755721)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |<>)
-                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
+                                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195756046) (:text |{})
+                                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608195756833)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |string/replace)
-                                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |k)
-                                                  |r $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185683810)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text |re-pattern)
-                                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text "|\"^/\\w+/\\w+/")
-                                                  |v $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185683810) (:text "|\"~/")
+                                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195756833) (:text |:class-name)
+                                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608195767748) (:text "|\"close-icon")
                       |n $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185994385)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608186003714) (:text |remove)
@@ -6173,6 +6138,24 @@
                                   |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185999580) (:text |=)
                                   |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608186014344) (:text |v)
                                   |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608186001817) (:text |current)
+                      |p $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486302675)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486307630) (:text |sort-by)
+                          |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486308253)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486308758) (:text |fn)
+                              |j $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486346184)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486309015)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486309867) (:text |[])
+                                      |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486310127) (:text |k)
+                                      |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486310467) (:text |v)
+                              |r $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486311356) (:text |v)
+                              |n $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1613486328018)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486329065) (:text |println)
+                                  |j $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1613486329451) (:text |v)
               |n $ {} (:type :expr) (:by |B1y7Rc-Zz) (:at 1608185687778)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |B1y7Rc-Zz) (:at 1608185689793) (:text |footprints)

--- a/src/app/comp/home.cljs
+++ b/src/app/comp/home.cljs
@@ -61,28 +61,28 @@
   {:style {:max-width 280}}
   (->> footprints
        (remove (fn [[k v]] (= v current)))
+       (sort-by (fn [[k v]] (println v) v))
        (map
         (fn [[k v]]
           [k
            (div
-            {:style {:line-height 1.2,
-                     :padding "6px 4px",
-                     :overflow :hidden,
-                     :cursor :pointer},
+            {:style (merge
+                     ui/row-parted
+                     {:line-height "1.4em",
+                      :padding "6px 6px",
+                      :font-size 13,
+                      :overflow :hidden,
+                      :cursor :pointer}),
              :class-name "hoverable",
-             :on-click (fn [e d!] (d! :effect/switch-path k))}
-            (div
-             {:style ui/row-parted}
-             (<> v ui/expand)
-             (span
-              {:class-name "close-icon"}
-              (comp-icon
-               :x
-               {:font-size 14, :color (hsl 0 90 70)}
-               (fn [e d!] (d! :session/drop-footprint k)))))
-            (div
-             {:style {:font-size 10, :color (hsl 0 0 70)}}
-             (<> (string/replace k (re-pattern "^/\\w+/\\w+/") "~/"))))])))))
+             :on-click (fn [e d!] (d! :effect/switch-path k)),
+             :title k}
+            (<> v ui/expand)
+            (span
+             {:class-name "close-icon"}
+             (comp-icon
+              :x
+              {:font-size 14, :color (hsl 0 90 70)}
+              (fn [e d!] (d! :session/drop-footprint k)))))])))))
 
 (def style-log
   {:line-height "20px",


### PR DESCRIPTION
based on real usages, footprints are not quite useful since picking an item from list is not fast enough.